### PR TITLE
[WEB-79] B2C Ecommerce Stats Section

### DIFF
--- a/src/app/(layout_pages)/services/b2c-retail-ecommerce/page.tsx
+++ b/src/app/(layout_pages)/services/b2c-retail-ecommerce/page.tsx
@@ -3,6 +3,7 @@ import {
   B2CWeAreDifferent,
   B2ConcernsExpertise,
   B2CHelp,
+  B2CStats,
 } from "@/components/B2CEcommerceComponent";
 import React from "react";
 
@@ -13,6 +14,7 @@ const page = () => {
       <B2CWeAreDifferent />
       <B2ConcernsExpertise />
       <B2CHelp />
+      <B2CStats />
     </main>
   );
 };

--- a/src/components/B2CEcommerceComponent/B2CHelp.tsx
+++ b/src/components/B2CEcommerceComponent/B2CHelp.tsx
@@ -5,7 +5,7 @@ import { B2C_HELP_HEADING } from "@/constants/b2c_ecommerce";
 const B2CHelp = () => {
   return (
     <section id="help_every_step">
-      <div className="wrapper_container mb-24 ">
+      <div className="wrapper_container mb-12 mb:mb-24 ">
         <div className=" md:mx-6 lg:mx-10 xl:mx-16 flex flex-col lg:flex-row gap-8 lg:gap-16 xl:gap-16  2xl:gap-28 max-w-[725px] lg:max-w-fit mx-auto">
           <div className="lg:basis-[70%] xl:basis-[60%]">
             <h1 className=" text-2xl sm:text-2xl  xl:text-4xl font-[700] text-gray-800 !leading-[1.25]   ">

--- a/src/components/B2CEcommerceComponent/B2CHelp.tsx
+++ b/src/components/B2CEcommerceComponent/B2CHelp.tsx
@@ -8,7 +8,7 @@ const B2CHelp = () => {
       <div className="wrapper_container mb-12 mb:mb-24 ">
         <div className=" md:mx-6 lg:mx-10 xl:mx-16 flex flex-col lg:flex-row gap-8 lg:gap-16 xl:gap-16  2xl:gap-28 max-w-[725px] lg:max-w-fit mx-auto">
           <div className="lg:basis-[70%] xl:basis-[60%]">
-            <h1 className=" text-2xl sm:text-2xl  xl:text-4xl font-[700] text-gray-800 !leading-[1.25]   ">
+            <h1 className=" text-2xl sm:text-2xl  xl:text-4xl font-[700] text-gray-800 !leading-[1.32]   ">
               {B2C_HELP_HEADING}
             </h1>
           </div>

--- a/src/components/B2CEcommerceComponent/B2CStats.tsx
+++ b/src/components/B2CEcommerceComponent/B2CStats.tsx
@@ -1,15 +1,13 @@
 import React from "react";
 import B2CStatsContainer from "./B2CStatsContainer";
+import { B2C_STATS_HEADING } from "@/constants/b2c_ecommerce";
 
 const B2CStats = () => {
-  //   return <section id="ecommerce_stats" className="bg-white-100"></section>;
-
   return (
-    <section id="results" className="bg-white-100 py-10 mb-24">
+    <section id="results" className="bg-white-100 py-20 mb-24">
       <div className="wrapper_container  ">
         <h1 className="md:mx-6 lg:mx-10 xl:mx-16 text-2xl sm:text-2xl  xl:text-4xl font-[700] text-gray-800 !leading-[1.32]   text-center mb-10">
-          Uplift eCommerce experience for globally renowned brands through
-          expertise
+          {B2C_STATS_HEADING}
         </h1>
 
         <B2CStatsContainer />

--- a/src/components/B2CEcommerceComponent/B2CStats.tsx
+++ b/src/components/B2CEcommerceComponent/B2CStats.tsx
@@ -5,8 +5,8 @@ const B2CStats = () => {
   //   return <section id="ecommerce_stats" className="bg-white-100"></section>;
 
   return (
-    <section id="results">
-      <div className="wrapper_container my-24 ">
+    <section id="results" className="bg-white-100 py-10 mb-24">
+      <div className="wrapper_container  ">
         <h1 className="md:mx-6 lg:mx-10 xl:mx-16 text-2xl sm:text-2xl  xl:text-4xl font-[700] text-gray-800 !leading-[1.32]   text-center mb-10">
           Uplift eCommerce experience for globally renowned brands through
           expertise

--- a/src/components/B2CEcommerceComponent/B2CStats.tsx
+++ b/src/components/B2CEcommerceComponent/B2CStats.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const B2CStats = () => {
+  return <section id="ecommerce_stats" className="bg-white-100"></section>;
+};
+
+export default B2CStats;

--- a/src/components/B2CEcommerceComponent/B2CStats.tsx
+++ b/src/components/B2CEcommerceComponent/B2CStats.tsx
@@ -1,7 +1,18 @@
 import React from "react";
 
 const B2CStats = () => {
-  return <section id="ecommerce_stats" className="bg-white-100"></section>;
+  //   return <section id="ecommerce_stats" className="bg-white-100"></section>;
+
+  return (
+    <section id="results">
+      <div className="wrapper_container my-24 ">
+        <h1 className=" text-2xl sm:text-2xl  xl:text-4xl font-[700] text-gray-800 !leading-[1.32]   text-center mb-10">
+          Uplift eCommerce experience for globally renowned brands through
+          expertise
+        </h1>
+      </div>
+    </section>
+  );
 };
 
 export default B2CStats;

--- a/src/components/B2CEcommerceComponent/B2CStats.tsx
+++ b/src/components/B2CEcommerceComponent/B2CStats.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import B2CStatsContainer from "./B2CStatsContainer";
 
 const B2CStats = () => {
   //   return <section id="ecommerce_stats" className="bg-white-100"></section>;
@@ -6,10 +7,12 @@ const B2CStats = () => {
   return (
     <section id="results">
       <div className="wrapper_container my-24 ">
-        <h1 className=" text-2xl sm:text-2xl  xl:text-4xl font-[700] text-gray-800 !leading-[1.32]   text-center mb-10">
+        <h1 className="md:mx-6 lg:mx-10 xl:mx-16 text-2xl sm:text-2xl  xl:text-4xl font-[700] text-gray-800 !leading-[1.32]   text-center mb-10">
           Uplift eCommerce experience for globally renowned brands through
           expertise
         </h1>
+
+        <B2CStatsContainer />
       </div>
     </section>
   );

--- a/src/components/B2CEcommerceComponent/B2CStatsContainer.tsx
+++ b/src/components/B2CEcommerceComponent/B2CStatsContainer.tsx
@@ -1,20 +1,20 @@
 import React from "react";
-import { RESULTS_DELIVERED } from "@/prototypes/results";
+import { B2C_ECOMMERCE_STATS } from "@/prototypes/b2c";
 
 const B2CStatsContainer = () => {
   return (
     <div className="  md:hidden grid grid-cols-2  gap-4 lg:gap-0 item-center justify-center">
-      {RESULTS_DELIVERED.map(({ title, value }) => (
-        <div key={title} className="flex flex-col justify-center items-center">
+      {B2C_ECOMMERCE_STATS.map(({ title, value }) => (
+        <div key={title} className="flex flex-col justify-center items-center ">
           <div className="flex flex-center">
-            <h2 className="text-4xl  sm:text-5xl font-[500] text-gray-800">
+            <h2 className="text-4xl  sm:text-[2.8rem] font-[500] text-gray-800">
               {value}
             </h2>
             <div className="text-6xl lg:text-5xl  xl:text-7xl font-[400] text-red ">
               +
             </div>
           </div>
-          <div className="text-sm sm:text-lg lg:text-[1.2rem] xl:text-[1.5rem] font-[600] text-gray-800">
+          <div className="text-xs sm:text-lg lg:text-[1.2rem] xl:text-[1.5rem] font-[600] text-gray-800 text-center">
             {title}
           </div>
         </div>

--- a/src/components/B2CEcommerceComponent/B2CStatsContainer.tsx
+++ b/src/components/B2CEcommerceComponent/B2CStatsContainer.tsx
@@ -4,8 +4,15 @@ import { B2C_ECOMMERCE_STATS } from "@/prototypes/b2c";
 import Slider from "react-slick";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
+import B2CStatsTile from "./B2CStatsTile";
 
 const B2CStatsContainer = () => {
+  const ecommerceStatsArray = B2C_ECOMMERCE_STATS.map(
+    ({ title, value }, index) => (
+      <B2CStatsTile key={index} title={title} value={value} />
+    )
+  );
+
   let settings = {
     dots: false,
     infinite: true,
@@ -29,46 +36,12 @@ const B2CStatsContainer = () => {
   return (
     <>
       <div className="  md:hidden grid grid-cols-2  gap-4 lg:gap-0 item-center justify-center md:mx-6 lg:mx-10 xl:mx-16">
-        {B2C_ECOMMERCE_STATS.map(({ title, value }) => (
-          <div
-            key={title}
-            className="flex flex-col justify-center items-center "
-          >
-            <div className="flex flex-center">
-              <h2 className="text-4xl  sm:text-[2.8rem] font-[500] text-gray-800">
-                {value}
-              </h2>
-              <div className="text-6xl lg:text-5xl  xl:text-7xl font-[400] text-red ">
-                +
-              </div>
-            </div>
-            <div className="text-xs sm:text-lg lg:text-[1.2rem] xl:text-[1.5rem] font-[600] text-gray-800 text-center">
-              {title}
-            </div>
-          </div>
-        ))}
+        {ecommerceStatsArray}
       </div>
 
       <div className="hidden md:block md:mx-6 lg:mx-10 xl:mx-16">
         <Slider {...settings} className="hidden md:block">
-          {B2C_ECOMMERCE_STATS.map(({ title, value }) => (
-            <div
-              key={title}
-              className="flex flex-col justify-center items-center px-2 "
-            >
-              <div className="flex flex-center">
-                <h2 className="text-4xl  sm:text-[2.8rem] font-[500] text-gray-800">
-                  {value}
-                </h2>
-                <div className="text-6xl lg:text-5xl  xl:text-7xl font-[400] text-red ">
-                  +
-                </div>
-              </div>
-              <div className=" sm:text-base font-[600] text-gray-400 text-center mt-2">
-                {title}
-              </div>
-            </div>
-          ))}
+          {ecommerceStatsArray}
         </Slider>
       </div>
     </>

--- a/src/components/B2CEcommerceComponent/B2CStatsContainer.tsx
+++ b/src/components/B2CEcommerceComponent/B2CStatsContainer.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { RESULTS_DELIVERED } from "@/prototypes/results";
+
+const B2CStatsContainer = () => {
+  return (
+    <div className="  md:hidden grid grid-cols-2  gap-4 lg:gap-0 item-center justify-center">
+      {RESULTS_DELIVERED.map(({ title, value }) => (
+        <div key={title} className="flex flex-col justify-center items-center">
+          <div className="flex flex-center">
+            <h2 className="text-4xl  sm:text-5xl font-[500] text-gray-800">
+              {value}
+            </h2>
+            <div className="text-6xl lg:text-5xl  xl:text-7xl font-[400] text-red ">
+              +
+            </div>
+          </div>
+          <div className="text-sm sm:text-lg lg:text-[1.2rem] xl:text-[1.5rem] font-[600] text-gray-800">
+            {title}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default B2CStatsContainer;

--- a/src/components/B2CEcommerceComponent/B2CStatsContainer.tsx
+++ b/src/components/B2CEcommerceComponent/B2CStatsContainer.tsx
@@ -1,25 +1,77 @@
+"use client";
 import React from "react";
 import { B2C_ECOMMERCE_STATS } from "@/prototypes/b2c";
+import Slider from "react-slick";
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
 
 const B2CStatsContainer = () => {
+  let settings = {
+    dots: false,
+    infinite: true,
+    slidesToShow: 6,
+    slidesToScroll: 1,
+    autoplay: true,
+    speed: 300,
+    autoplaySpeed: 1000,
+    cssEase: "ease-in-out",
+    responsive: [
+      {
+        breakpoint: 1024,
+        settings: {
+          slidesToShow: 3,
+          slidesToScroll: 1,
+          initialSlide: 1,
+        },
+      },
+    ],
+  };
   return (
-    <div className="  md:hidden grid grid-cols-2  gap-4 lg:gap-0 item-center justify-center">
-      {B2C_ECOMMERCE_STATS.map(({ title, value }) => (
-        <div key={title} className="flex flex-col justify-center items-center ">
-          <div className="flex flex-center">
-            <h2 className="text-4xl  sm:text-[2.8rem] font-[500] text-gray-800">
-              {value}
-            </h2>
-            <div className="text-6xl lg:text-5xl  xl:text-7xl font-[400] text-red ">
-              +
+    <>
+      <div className="  md:hidden grid grid-cols-2  gap-4 lg:gap-0 item-center justify-center md:mx-6 lg:mx-10 xl:mx-16">
+        {B2C_ECOMMERCE_STATS.map(({ title, value }) => (
+          <div
+            key={title}
+            className="flex flex-col justify-center items-center "
+          >
+            <div className="flex flex-center">
+              <h2 className="text-4xl  sm:text-[2.8rem] font-[500] text-gray-800">
+                {value}
+              </h2>
+              <div className="text-6xl lg:text-5xl  xl:text-7xl font-[400] text-red ">
+                +
+              </div>
+            </div>
+            <div className="text-xs sm:text-lg lg:text-[1.2rem] xl:text-[1.5rem] font-[600] text-gray-800 text-center">
+              {title}
             </div>
           </div>
-          <div className="text-xs sm:text-lg lg:text-[1.2rem] xl:text-[1.5rem] font-[600] text-gray-800 text-center">
-            {title}
-          </div>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+
+      <div className="hidden md:block md:mx-6 lg:mx-10 xl:mx-16">
+        <Slider {...settings} className="hidden md:block">
+          {B2C_ECOMMERCE_STATS.map(({ title, value }) => (
+            <div
+              key={title}
+              className="flex flex-col justify-center items-center px-2 "
+            >
+              <div className="flex flex-center">
+                <h2 className="text-4xl  sm:text-[2.8rem] font-[500] text-gray-800">
+                  {value}
+                </h2>
+                <div className="text-6xl lg:text-5xl  xl:text-7xl font-[400] text-red ">
+                  +
+                </div>
+              </div>
+              <div className=" sm:text-base font-[600] text-gray-400 text-center mt-2">
+                {title}
+              </div>
+            </div>
+          ))}
+        </Slider>
+      </div>
+    </>
   );
 };
 

--- a/src/components/B2CEcommerceComponent/B2CStatsTile.tsx
+++ b/src/components/B2CEcommerceComponent/B2CStatsTile.tsx
@@ -1,7 +1,24 @@
 import React from "react";
-
-const B2CStatsTile = () => {
-  return <div>B2CStatsTile</div>;
+type B2CStatsTileProps = {
+  title: string;
+  value: string;
+};
+const B2CStatsTile = ({ title, value }: B2CStatsTileProps) => {
+  return (
+    <div key={title} className="flex flex-col justify-center items-center ">
+      <div className="flex flex-center">
+        <h2 className="text-4xl  sm:text-[2.8rem] font-[500] text-gray-800">
+          {value}
+        </h2>
+        <div className="text-6xl lg:text-5xl  xl:text-7xl font-[400] text-red ">
+          +
+        </div>
+      </div>
+      <div className="text-xs sm:text-lg md:text-base font-[600] text-gray-800 text-center">
+        {title}
+      </div>
+    </div>
+  );
 };
 
 export default B2CStatsTile;

--- a/src/components/B2CEcommerceComponent/B2CStatsTile.tsx
+++ b/src/components/B2CEcommerceComponent/B2CStatsTile.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const B2CStatsTile = () => {
+  return <div>B2CStatsTile</div>;
+};
+
+export default B2CStatsTile;

--- a/src/components/B2CEcommerceComponent/B2ConcernsExpertise.tsx
+++ b/src/components/B2CEcommerceComponent/B2ConcernsExpertise.tsx
@@ -5,7 +5,7 @@ import ConcernExpertiseContainer from "./ConcernExpertiseContainer";
 const B2ConcernsExpertise = () => {
   return (
     <section id="concerns_and_expertise">
-      <div className="wrapper_container mb-24">
+      <div className="wrapper_container mb-12 md:mb-24">
         <div className="md:mx-6 lg:mx-10 xl:mx-16 mb-12 flex gap-6">
           <div className="max-w-[650px] basis-full">
             <ConcernExpertiseContainer />

--- a/src/components/B2CEcommerceComponent/index.ts
+++ b/src/components/B2CEcommerceComponent/index.ts
@@ -2,6 +2,7 @@ import B2CHelp from "./B2CHelp";
 import B2CHelpTab from "./B2CHelpTab";
 import B2CHelpTabs from "./B2CHelpTabs";
 import B2CHero from "./B2CHero";
+import B2CStats from "./B2CStats";
 import B2CWeAreDifferent from "./B2CWeAreDifferent";
 import B2ConcernsExpertise from "./B2ConcernsExpertise";
 import ConcernExpertiseContainer from "./ConcernExpertiseContainer";
@@ -15,4 +16,5 @@ export {
   B2CHelp,
   B2CHelpTabs,
   B2CHelpTab,
+  B2CStats,
 };

--- a/src/components/B2CEcommerceComponent/index.ts
+++ b/src/components/B2CEcommerceComponent/index.ts
@@ -3,10 +3,12 @@ import B2CHelpTab from "./B2CHelpTab";
 import B2CHelpTabs from "./B2CHelpTabs";
 import B2CHero from "./B2CHero";
 import B2CStats from "./B2CStats";
+import B2CStatsContainer from "./B2CStatsContainer";
 import B2CWeAreDifferent from "./B2CWeAreDifferent";
 import B2ConcernsExpertise from "./B2ConcernsExpertise";
 import ConcernExpertiseContainer from "./ConcernExpertiseContainer";
 import RetailerListLayout from "./RetailerListLayout";
+
 export {
   B2CHero,
   B2CWeAreDifferent,
@@ -17,4 +19,5 @@ export {
   B2CHelpTabs,
   B2CHelpTab,
   B2CStats,
+  B2CStatsContainer,
 };

--- a/src/components/B2CEcommerceComponent/index.ts
+++ b/src/components/B2CEcommerceComponent/index.ts
@@ -4,11 +4,11 @@ import B2CHelpTabs from "./B2CHelpTabs";
 import B2CHero from "./B2CHero";
 import B2CStats from "./B2CStats";
 import B2CStatsContainer from "./B2CStatsContainer";
+import B2CStatsTile from "./B2CStatsTile";
 import B2CWeAreDifferent from "./B2CWeAreDifferent";
 import B2ConcernsExpertise from "./B2ConcernsExpertise";
 import ConcernExpertiseContainer from "./ConcernExpertiseContainer";
 import RetailerListLayout from "./RetailerListLayout";
-
 export {
   B2CHero,
   B2CWeAreDifferent,
@@ -20,4 +20,5 @@ export {
   B2CHelpTab,
   B2CStats,
   B2CStatsContainer,
+  B2CStatsTile,
 };

--- a/src/constants/b2c_ecommerce/index.ts
+++ b/src/constants/b2c_ecommerce/index.ts
@@ -17,3 +17,6 @@ export const WHAT_WE_DO = "WHAT WE DO";
 export const THE_OUTCOME = "THE OUTCOME";
 export const B2C_HELP_HEADING =
   "We help you on every step of your B2C eCommerce journey, so you can always focus on what truly matters.";
+
+export const B2C_STATS_HEADING =
+  "Uplift eCommerce experience for globally renowned brands through expertise";

--- a/src/prototypes/b2c/index.ts
+++ b/src/prototypes/b2c/index.ts
@@ -246,3 +246,12 @@ export const HELP_PROVIDED = [
     },
   },
 ];
+
+export const B2C_ECOMMERCE_STATS = [
+  { title: "Store Launched", value: "260" },
+  { title: "Product Management Experience", value: "10m" },
+  { title: "Daily Order Management Experience", value: "4m" },
+  { title: "Shipping Gateway Integrated", value: "50" },
+  { title: "Payment Gateway Integrated", value: "30" },
+  { title: "ERP and CRM, Pim, and Dam Integrated", value: "35" },
+];


### PR DESCRIPTION
# Description

Added B2C Ecommerce Stats section with slider in b2c route.
Dependency
- React Slick Slider


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Has been Tested manually in the web browser and the responsive panel

- [x] Manually Resized the screen size
- [x] Checking in different devices

# Checklist:

- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# Screenshots
![stats](https://github.com/SoftSonicDigitals/soft-sonic-digitals-frontend/assets/103564854/791fde99-01a3-47b6-9970-0da9e3f79f22)

If relevant, include screenshots / video of the changes
